### PR TITLE
fix: adding missing configuration file

### DIFF
--- a/packages/aws/config.dist.json
+++ b/packages/aws/config.dist.json
@@ -1,0 +1,7 @@
+{
+    "toolTitle": "Videos & audio (S3)",
+    "defaultAccept": [
+        "video/*",
+        "audio/*"
+    ]
+}

--- a/packages/aws/src/config.ts
+++ b/packages/aws/src/config.ts
@@ -1,4 +1,4 @@
-import pluginConfig from 'config:s3-dam?';
+import pluginConfig from 'config:s3-dam';
 import { VendorConfiguration } from 'sanity-plugin-external-dam/lib/types'
 import {
   LockIcon,
@@ -8,18 +8,13 @@ import {
   EarthGlobeIcon,
 } from '@sanity/icons'
 
-export const DEFAULT_ACCEPT = [
-  'video/*',
-  'audio/*',
-]
-
-const { defaultAccept, toolTitle } = pluginConfig ?? {};
+const { defaultAccept, toolTitle } = pluginConfig;
 
 const config: VendorConfiguration = {
   id: 's3-dam',
   customDataFieldName: 's3',
-  defaultAccept: defaultAccept ?? DEFAULT_ACCEPT,
-  toolTitle: toolTitle ?? 'Videos & audio (S3)',
+  defaultAccept,
+  toolTitle,
   credentialsFields: [
     {
       name: 'bucketKey',

--- a/packages/aws/src/partTypes.d.ts
+++ b/packages/aws/src/partTypes.d.ts
@@ -1,1 +1,1 @@
-declare module 'config:s3-dam?'
+declare module 'config:s3-dam'

--- a/packages/digital-ocean/config.dist.json
+++ b/packages/digital-ocean/config.dist.json
@@ -1,0 +1,7 @@
+{
+    "toolTitle": "Videos & audio (DigitalOcean)",
+    "defaultAccept": [
+        "video/*",
+        "audio/*"
+    ]
+}

--- a/packages/digital-ocean/src/config.ts
+++ b/packages/digital-ocean/src/config.ts
@@ -1,4 +1,4 @@
-import pluginConfig from 'config:digital-ocean-files?';
+import pluginConfig from 'config:digital-ocean-files';
 import { VendorConfiguration } from 'sanity-plugin-external-dam/lib/types'
 import {
   LockIcon,
@@ -9,15 +9,13 @@ import {
   ApiIcon,
 } from '@sanity/icons'
 
-export const DEFAULT_ACCEPT = ['video/*', 'audio/*']
-
-const { defaultAccept, toolTitle } = pluginConfig ?? {};
+const { defaultAccept, toolTitle } = pluginConfig;
 
 const config: VendorConfiguration = {
   id: 'digital-ocean-files',
   customDataFieldName: 'digitalOcean',
-  defaultAccept: defaultAccept ?? DEFAULT_ACCEPT,
-  toolTitle: toolTitle ?? 'Videos & audio (DigitalOcean)',
+  defaultAccept,
+  toolTitle,
   credentialsFields: [
     {
       name: 'bucketKey',

--- a/packages/digital-ocean/src/partTypes.d.ts
+++ b/packages/digital-ocean/src/partTypes.d.ts
@@ -1,1 +1,1 @@
-declare module 'config:digital-ocean-files?'
+declare module 'config:digital-ocean-files'

--- a/packages/firebase/config.dist.json
+++ b/packages/firebase/config.dist.json
@@ -1,0 +1,7 @@
+{
+    "toolTitle": "Videos & Audio (Firebase)",
+    "defaultAccept": [
+        "video/*",
+        "audio/*"
+    ]
+}

--- a/packages/firebase/src/config.ts
+++ b/packages/firebase/src/config.ts
@@ -1,20 +1,15 @@
-import pluginConfig from 'config:firebase-dam?';
+import pluginConfig from 'config:firebase-dam';
 import { VendorConfiguration } from 'sanity-plugin-external-dam/lib/types'
 import { LockIcon, LinkIcon } from '@sanity/icons'
 import getFirebaseClient, { FirebaseCredentials } from './getFirebaseClient'
 
-export const DEFAULT_ACCEPT = [
-  'video/*',
-  'audio/*',
-]
-
-const { defaultAccept, toolTitle } = pluginConfig ?? {};
+const { defaultAccept, toolTitle } = pluginConfig;
 
 const config: VendorConfiguration = {
   id: 'firebase-dam',
   customDataFieldName: 'firebase',
-  defaultAccept: defaultAccept ?? DEFAULT_ACCEPT,
-  toolTitle: toolTitle ?? "Videos & Audio (Firebase)",
+  defaultAccept,
+  toolTitle,
   supportsProgress: true,
   credentialsFields: [
     {

--- a/packages/firebase/src/partTypes.d.ts
+++ b/packages/firebase/src/partTypes.d.ts
@@ -1,1 +1,1 @@
-declare module 'config:firebase-dam?'
+declare module 'config:firebase-dam'


### PR DESCRIPTION
Adding a configuration file to the newest version ([0.7.0](https://www.npmjs.com/package/sanity-plugin-s3-dam/v/0.7.0)) has broken this plugin. See #2 

```
$ sanity start
✔ Checking configuration files...
⠴ Compiling...webpack built f49c8ff68888cf0e8c27 in 5059ms
✔ Compiling...
Failed to compile.

Error in ./node_modules/sanity-plugin-s3-dam/lib/config.js
Module not found: Error: Can't resolve 'config:s3-dam?' in './s3-dam-test/node_modules/sanity-plugin-s3-dam/lib'
 @ ./node_modules/sanity-plugin-s3-dam/lib/config.js 16:40-65
 @ ./node_modules/sanity-plugin-s3-dam/lib/schemas/s3-dam.custom-data.js
 @ ./node_modules/sanity-plugin-s3-dam/lib/schemas/s3-dam.custom-data.js (all:part:@sanity/base/schema-type)
 @ ./schemas/schema.js (part:@sanity/base/schema)
 @ ./node_modules/@sanity/base/lib/util/getNewDocumentOptions.js
 @ ./node_modules/@sanity/base/lib/_exports/_internal.js
 @ ./node_modules/@sanity/base/_internal.js
 @ ./node_modules/@sanity/default-layout/lib/defaultLayout/DefaultLayout.js
 @ ./node_modules/@sanity/default-layout/lib/defaultLayout/index.js
 @ ./node_modules/@sanity/default-layout/lib/Root.js (part:@sanity/base/root)
 @ ./node_modules/@sanity/base/lib/components/SanityRoot.js (part:@sanity/base/sanity-root)
 @ ./node_modules/@sanity/server/lib/browser/entry-dev.js
 @ multi ./node_modules/@sanity/server/lib/browser/entry-dev.js
```

I've added a default configuration file `config.dist.json` and adjusted the imports to be required (`config:s3-dam`)

I might need another pair of eyes on this though to make sure the types are included in the library bundle (`packages/aws/src/partTypes.d.ts`)?