### PR TITLE
sanity requires keys on documents. added a uuid to the asset created

### DIFF
--- a/packages/core/src/components/CreateInput.tsx
+++ b/packages/core/src/components/CreateInput.tsx
@@ -28,6 +28,7 @@ export default function createInput(vendorConfig: VendorConfiguration) {
     const updateValue = useCallback(
       (document: SanityUpload) => {
         const patchValue = {
+          _key: crypto.randomUUID(),
           _type: schemaType.name,
           asset: {
             _type: 'reference',


### PR DESCRIPTION
This simply adds a `_key` value to the asset document when created. Sanity requires this and will give a warning if it doesn't exist and won't allow you edit the list without it.